### PR TITLE
poc: bulk create I/F

### DIFF
--- a/t/Type-Kote/create.t
+++ b/t/Type-Kote/create.t
@@ -1,0 +1,44 @@
+use Test2::V0;
+
+use Types::Standard qw(Str);
+
+use kote Foo => Str;
+
+subtest 'single value' => sub {
+    my ($err, $foo) = Foo->create('foo');
+    is $err, undef, 'no error';
+};
+
+subtest 'multiple values' => sub {
+    my ($err, $foo, $bar) = Foo->create('foo', 'bar');
+    is $err, undef, 'no error';
+    is $foo, 'foo';
+    is $bar, 'bar';
+
+    ($err, my @values) = Foo->create('foo', 'bar');
+    is $err, undef, 'no error';
+    is \@values, ['foo', 'bar'];
+};
+
+subtest 'single illegal value' => sub {
+    my ($err, $foo) = Foo->create({});
+    ok $err;
+    note $err;
+    is $foo, undef;
+};
+
+subtest 'multiple illegal values' => sub {
+    my ($err, $foo, $bar) = Foo->create({}, 'bar');
+    ok $err;
+    note $err;
+    is $foo, undef;
+    is $bar, undef;
+};
+
+subtest 'no value' => sub{
+    my ($err, $foo) = Foo->create();
+    ok !$err;
+    is $foo, undef;
+};
+
+done_testing;


### PR DESCRIPTION
## Motivation

What is the best way to create multiple values? It would be inconvenient to write the following code over and over again.

```perl
    my ($result, $err);
    for (qw(foo bar)) {
        (my $v, $err) = Foo->create($_);
        last if $err;
        push $result->@*, $v;
    }

    is $err, undef, 'no error';
    is $result, ['foo', 'bar'];
```

## Which one do you prefer?

- 1 Add `create_multi` method
- 2 The first is error
- 3 Define LIST type
- 4 Add `list` method

### 1. Add `create_multi` method

```perl
use kote Foo => Str;

my ($result, $err) = Foo->create_multi('foo', 'bar');
$result # => ['foo', 'bar']

my ($result, $err) = Foo->create_multi({}, 'bar');
ok $err;
````

### 2. The first is error

```perl
my ($err, @result) = Foo->create('foo', 'bar');
@result # => ('foo', 'bar')

my ($err, $foo, $bar) = Foo->create('foo', 'bar');
$foo #  => 'foo'

my ($err, @result) = Foo->create({}, 'bar');
ok $err;
```

### 3. Define LIST type

```perl
use kote Foo => Str;
use kote FooList => ArrayRef[Str];

my ($result, $err) = FooList->create(['foo', 'bar']);
$result # => ['foo', 'bar']
```

### 4. Add `list` method

```perl
use kote Foo => Str;

my ($result, $err) = Foo->list->create(['foo', 'bar']);
$result # => ['foo', 'bar']